### PR TITLE
Fix tick interrupt priority issue

### DIFF
--- a/src/arch/armv8/irq.c
+++ b/src/arch/armv8/irq.c
@@ -2,13 +2,15 @@
 #include <cpu.h>
 #include <gic.h>
 
+#include <FreeRTOS.h>
+
 #ifndef GIC_VERSION
 #error "GIC_VERSION not defined for this platform"
 #endif
 
 void irq_enable(unsigned id) {
    gic_set_enable(id, true); 
-   gic_set_prio(id, 0);
+   gic_set_prio(id, portLOWEST_USABLE_INTERRUPT_PRIORITY << portPRIORITY_SHIFT);
    if(GIC_VERSION == GICV2) {
        gic_set_trgt(id, 1 << get_cpuid());
    } else {

--- a/src/freertos/portable/GCC/ARM_CA53_64_BIT/port.c
+++ b/src/freertos/portable/GCC/ARM_CA53_64_BIT/port.c
@@ -404,11 +404,7 @@ void vPortExitCritical( void )
 void FreeRTOS_Tick_Handler( void )
 {
 	/* Must be the lowest possible priority. */
-	#if !defined( QEMU )
-	{
-		configASSERT( portICCRPR_RUNNING_PRIORITY_REGISTER == ( uint32_t ) ( portLOWEST_USABLE_INTERRUPT_PRIORITY << portPRIORITY_SHIFT ) );
-	}
-	#endif
+	configASSERT( portICCRPR_RUNNING_PRIORITY_REGISTER == ( uint32_t ) ( portLOWEST_USABLE_INTERRUPT_PRIORITY << portPRIORITY_SHIFT ) );
 
 	/* Interrupts should not be enabled before this point. */
 	#if( configASSERT_DEFINED == 1 )
@@ -426,7 +422,7 @@ void FreeRTOS_Tick_Handler( void )
 	necessary to turn off interrupts in the CPU itself while the ICCPMR is being
 	updated. */
 #if (GIC_VERSION == GICV2)
-	//portICCPMR_PRIORITY_MASK_REGISTER = ( uint32_t ) ( configMAX_API_CALL_INTERRUPT_PRIORITY << portPRIORITY_SHIFT );
+	portICCPMR_PRIORITY_MASK_REGISTER = ( uint32_t ) ( configMAX_API_CALL_INTERRUPT_PRIORITY << portPRIORITY_SHIFT );
 #else
 	MSR(ICC_PMR_EL1, ( configMAX_API_CALL_INTERRUPT_PRIORITY << portPRIORITY_SHIFT ));
 #endif


### PR DESCRIPTION
The tick interrupt is set to the maximum interrupt priority 0. As far as I know this is not ideal, as it is not presumed by the FreeRTOS sources. Or is there a specific reason why this was done?
The configASSERT that was excluded with -DQEMU fired because of the unconventionally assigned tick interrupt priority.