### PR TITLE
PIC for Stack Initialization

### DIFF
--- a/src/arch/armv8/start.S
+++ b/src/arch/armv8/start.S
@@ -77,7 +77,8 @@ wait_flag:
     mov x3, #SPSel_SP							
 	msr SPSEL, x3	
 
-    adr x1, _stack_base
+    adrp x1, :pg_hi21:_stack_base
+    add x1, x1, :lo12:_stack_base
     add x1, x1, #STACK_SIZE
     ldr x2, =STACK_SIZE
     madd x1, x0, x2, x1


### PR DESCRIPTION
By using adrp (33 bit) in the start code instead of ldr (21 bit) the application can now use close to 4 GB of code/data instead of 2 MB.